### PR TITLE
Make lodash a real actual dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
   },
   "homepage": "https://github.com/macropodhq/postcss-px-to-em",
   "dependencies": {
+    "lodash": "^3.10.0",
     "postcss": "^4.1.13"
   },
   "devDependencies": {
     "chai": "^3.0.0",
     "gulp": "^3.9.0",
     "gulp-eslint": "^0.14.0",
-    "gulp-mocha": "^2.1.2",
-    "lodash": "^3.10.0"
+    "gulp-mocha": "^2.1.2"
   },
   "scripts": {
     "test": "gulp"


### PR DESCRIPTION
Fixes issues using this in projects which don't natively include lodash