### PR TITLE
Update Postcss to ^5.0.14, updated deprecated eachInside and node._va…

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,10 +34,8 @@ module.exports = postcss.plugin('postcss-px-to-em', function (opts) {
   };
 
   return function (css) {
-    css.eachInside(function(node) {
-      if (node.type === 'decl') {
-        node.value = convert(node._value ? node._value.raw : node.value);
-      }
+     css.walkDecls(function(node) {
+      node.value = convert(node.raws.value ? node.raws.value.raw : node.value);
     });
   };
 });

--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
   },
   "homepage": "https://github.com/macropodhq/postcss-px-to-em",
   "dependencies": {
-    "lodash": "^3.10.0",
-    "postcss": "^4.1.13"
+    "lodash": "^3.10.0"
   },
   "devDependencies": {
     "chai": "^3.0.0",
     "gulp": "^3.9.0",
     "gulp-eslint": "^0.14.0",
-    "gulp-mocha": "^2.1.2"
+    "gulp-mocha": "^2.1.2",
+    "postcss": "^5.0.14"
   },
   "scripts": {
     "test": "gulp"


### PR DESCRIPTION
Hi, very handy tool, just updated the deprecated functions and parameters for value conversion. 